### PR TITLE
Fix for a string format argument index

### DIFF
--- a/Source/MVC5/Boilerplate.Web.Mvc5/Sitemap/SitemapGenerator.cs
+++ b/Source/MVC5/Boilerplate.Web.Mvc5/Sitemap/SitemapGenerator.cs
@@ -184,7 +184,7 @@
             {
                 this.LogWarning(new SitemapException(string.Format(
                     CultureInfo.CurrentCulture,
-                    "Sitemap index file exceeds the maximum number of allowed sitemaps of 50,000. Count:<{1}>",
+                    "Sitemap index file exceeds the maximum number of allowed sitemaps of 50,000. Count:<{0}>",
                     sitemapCount)));
             }
         }


### PR DESCRIPTION
A wrong argument index was used in `SiteMapGenerator.CheckSitemapCount` method. Spotted thanks to ReSharper :)