### PR TITLE
Add a Unity-compatible Boxed.Mapping.Unity package

### DIFF
--- a/Framework.sln
+++ b/Framework.sln
@@ -86,6 +86,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\release-drafter.yml = .github\workflows\release-drafter.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Boxed.Mapping.Unity", "Source\Boxed.Mapping\Boxed.Mapping.Unity.csproj", "{35F0C50B-BBE5-4F99-A507-B759A0EC717A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -132,6 +134,10 @@ Global
 		{1E0E624E-9291-4F6A-B68F-2E5FA178B6CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E0E624E-9291-4F6A-B68F-2E5FA178B6CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E0E624E-9291-4F6A-B68F-2E5FA178B6CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35F0C50B-BBE5-4F99-A507-B759A0EC717A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35F0C50B-BBE5-4F99-A507-B759A0EC717A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35F0C50B-BBE5-4F99-A507-B759A0EC717A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35F0C50B-BBE5-4F99-A507-B759A0EC717A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -151,6 +157,7 @@ Global
 		{0AC34385-AACA-424C-9F53-089FA4803330} = {DC7FDD72-F9C9-42E9-90CC-468BDD9A5CC2}
 		{1BD25AE7-6BA8-4120-BFF2-E1B0EF3D6E84} = {F316174B-045B-4DC0-9097-8CE746A8BBB0}
 		{828C70F2-431D-46A8-82BD-436A20BA146A} = {1BD25AE7-6BA8-4120-BFF2-E1B0EF3D6E84}
+		{35F0C50B-BBE5-4F99-A507-B759A0EC717A} = {D37BD4B2-A87B-4FA1-A1E0-01F1CAD19F0D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3BCEA536-0EA4-4EC0-B121-7B83926F8514}

--- a/Source/Boxed.Mapping/Boxed.Mapping.Unity.csproj
+++ b/Source/Boxed.Mapping/Boxed.Mapping.Unity.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Build">
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.3</TargetFrameworks>
+    <RootNamespace>Boxed.Mapping</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Package">
+    <Product>Object Mapping Boxed</Product>
+    <Description>An object to object mapper that does not use reflection. This is a Unity-compatible version.</Description>
+    <PackageTags>Mapper;Object Mapper;Automapper;Boxed;Muhammad Rehan Saeed;Framework;Unity</PackageTags>
+    <PackageReadmeFile>Boxed.Mapping.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Label="Files">
+    <None Include="..\..\Documentation\Boxed.Mapping.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Factory.cs" />
+  </ItemGroup>
+
+</Project>

--- a/Source/Boxed.Mapping/Boxed.Mapping.Unity.csproj
+++ b/Source/Boxed.Mapping/Boxed.Mapping.Unity.csproj
@@ -12,14 +12,6 @@
     <PackageReadmeFile>Boxed.Mapping.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>TRACE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>TRACE</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup Label="Files">
     <None Include="..\..\Documentation\Boxed.Mapping.md" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/Source/Boxed.Mapping/Boxed.Mapping.csproj
+++ b/Source/Boxed.Mapping/Boxed.Mapping.csproj
@@ -19,4 +19,8 @@
     <None Include="..\..\Documentation\Boxed.Mapping.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="Factory.Unity.cs" />
+  </ItemGroup>
+
 </Project>

--- a/Source/Boxed.Mapping/Factory.Unity.cs
+++ b/Source/Boxed.Mapping/Factory.Unity.cs
@@ -1,0 +1,20 @@
+namespace Boxed.Mapping;
+
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// Creates instances of type <typeparamref name="T"/>.
+/// </summary>
+/// <typeparam name="T">The type with a parameterless constructor.</typeparam>
+public static class Factory<T>
+    where T : new()
+{
+    /// <summary>
+    /// Creates an instance of type <typeparamref name="T"/> by calling it's parameterless constructor.
+    /// </summary>
+    /// <returns>An instance of type <typeparamref name="T"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#pragma warning disable CA1000 // Do not declare static members on generic types
+    public static T CreateInstance() => new();
+#pragma warning restore CA1000 // Do not declare static members on generic types
+}


### PR DESCRIPTION
This PR adds a new Boxed.Mapping.Unity package that fixes Unity incompatibilities described in #592

Implementation notes:

- I've decided to not introduce a new `UNITY` define symbol. Instead, I've made a separate copy of the `Factory.cs` file and added a `<Compile Remove>` tag to the `.csproj`s. I think this is a more readable and maintainable approach.
- I've added `[MethodImpl(MethodImplOptions.AggressiveInlining)]` attribute to the `Factory<T>.CreateInstance()` method. This will hint Unity to try and inline the method.
- I don't know all the details of the build pipeline, so you might need to do some additional actions for the package to appear on NuGet

Closes #592